### PR TITLE
fix: Correctly highlight "header" lines

### DIFF
--- a/jjdescription.el
+++ b/jjdescription.el
@@ -48,9 +48,14 @@ with `jjdescription-overflow-face'."
   "Face for `JJ:' comment lines."
   :group 'jjdescription)
 
-(defface jjdescription-header-face
+(defface jjdescription-header-key-face
   '((t :inherit font-lock-doc-face))
   "Face for headers within `JJ:' comment lines (e.g., `Conflicts:')."
+  :group 'jjdescription)
+
+(defface jjdescription-header-value-face
+  '((t :inherit font-lock-bracket-face))
+  "Face for values paired with headers within `JJ:' comment lines."
   :group 'jjdescription)
 
 (defface jjdescription-type-face
@@ -84,13 +89,14 @@ Sets match data: group 1 for text within length limit, group 2 for overflow."
   `((jjdescription--match-first-line
      (1 'jjdescription-summary-face prepend t)
      (2 'jjdescription-overflow-face prepend t))
-    ("JJ:[[:blank:]]+\\([A-Za-z][-_A-Za-z0-9]*:\\)"
-     (beginning-of-line) (end-of-line)
-     (1 'jjdescription-header-face prepend t))
-    ("[[:blank:]]+\\([CRMAD]\\)\\(.*\\)"
+    ("JJ:[[:blank:]]*\\([CRMAD]\\)[[:blank:]]+\\(.*\\)"
      (beginning-of-line) (end-of-line)
      (1 'jjdescription-type-face prepend t)
      (2 'jjdescription-file-face prepend t))
+    ("JJ:[[:blank:]]*\\([A-Za-z][-_A-Za-z0-9]*:\\)\\(.*\\)"
+     (beginning-of-line) (end-of-line)
+     (1 'jjdescription-header-key-face prepend t)
+     (2 'jjdescription-header-value-face prepend t))
     ("JJ:.*"
      (beginning-of-line) (end-of-line)
      (0 'jjdescription-comment-face append t)))

--- a/resources/test.jjdescription
+++ b/resources/test.jjdescription
@@ -17,6 +17,11 @@ JJ:     A Cargo.lock
 JJ:     A Cargo.toml
 JJ:     A src\main.rs
 JJ: Signed-Off-By: necaris
-JJ:   ^ (jjdescription-header-face jjdescription-comment-face)
+JJ:   ^ (jjdescription-header-key-face jjdescription-comment-face)
+JJ:                 ^ (jjdescription-header-value-face jjdescription-comment-face)
+JJ: Change-Id: 9837149
+JJ: ^ (jjdescription-header-key-face jjdescription-comment-face)
+JJ:  ^ (jjdescription-header-key-face jjdescription-comment-face)
+JJ:                 ^ (jjdescription-header-value-face jjdescription-comment-face)
 
 JJ: Lines starting with "JJ: " (like this one) will be removed.


### PR DESCRIPTION
Fix the bug where the first character of a header (if it's a file type, i.e. [CRMAD]) would be highlighted as a type. Also, while we're working on it, highlight the rest of the header line differently as well.